### PR TITLE
Fix truncated "action" on Cisco PIX/ASA

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1287,7 +1287,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   <parent>pix</parent>
   <type>firewall</type>
   <prematch offset="after_parent">^3-710003|^7-710002|^7-710005</prematch>
-  <regex offset="after_parent">^(\S+): (\S+) \w+ (\w+)\.+from </regex>
+  <regex offset="after_parent">^(\S+): (\S+) \w+ (\w+) \.+from </regex>
   <regex>(\S+)/(\S+) to \w+:(\S+)/(\S+)</regex>
   <order>id, protocol, action, srcip, srcport, dstip, dstport</order>
 </decoder>


### PR DESCRIPTION
This fixes the Cisco decoder from truncating the action.  Prior to this change, the decoder only picks up the first letter of the word 'denied'.

This can be verified with the existing sample logs - %PIX-3-710003: TCP access denied by ACL from 216.39.220.130/54065 to outside:62.192.113.98/ssh
