### PR TITLE
Include TS Gateway Events in msauth_rules.xml

### DIFF
--- a/etc/rules/msauth_rules.xml
+++ b/etc/rules/msauth_rules.xml
@@ -807,6 +807,29 @@
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
+  
+    <rule id="18257" level="3">
+    <if_sid>18101</if_sid>
+    <id>^200$|^300$|^302$</id>
+    <description>TS Gateway login success.</description>
+    <group>authentication_success,</group>
+    <info>https://technet.microsoft.com/en-us/library/cc775181(v=ws.10).aspx</info>
+  </rule>
+
+  <rule id="18258" level="5">
+    <if_sid>18102, 18103</if_sid>
+    <id>^201$|^203$|^204$|^301$|^304$|^305$|^306$|^1001$</id>
+    <description>TS Gateway login failure.</description>
+    <group>authentication_failed,</group>
+    <info>https://technet.microsoft.com/en-us/library/cc775181(v=ws.10).aspx</info>
+  </rule>
+
+  <rule id="18259" level="3">
+    <if_sid>18101</if_sid>
+    <id>^202$|^303$</id>
+    <description>TS Gateway user disconnected.</description>
+    <info>https://technet.microsoft.com/en-us/library/cc775181(v=ws.10).aspx</info>
+  </rule>
 
   <!-- Ignore Login events, type 5, from Advapi for:
     -  LOCAL SERVICE and NETWORK SERVICE.
@@ -909,6 +932,12 @@
   <rule id="18156" level="10" frequency="$MS_FREQ" timeframe="240">
     <if_matched_sid>18125</if_matched_sid>
     <description>Multiple remote access login failures.</description>
+    <group>authentication_failures,</group>
+  </rule>
+  
+    <rule id="18157" level="10" frequency="$MS_FREQ" timeframe="240">
+    <if_matched_sid>18258</if_matched_sid>
+    <description>Multiple TS Gateway login failures.</description>
     <group>authentication_failures,</group>
   </rule>
 </group>


### PR DESCRIPTION
Added events for TS Gateway - https://technet.microsoft.com/en-us/library/cc775181(v=ws.10).aspx

OSSEC client agent needs to monitor Microsoft-Windows-TerminalServices-Gateway/Operational event channel to receive these.
